### PR TITLE
Make prepended module redirect to_s to wrapping class

### DIFF
--- a/lib/grpc_typechecker/grpc_ext.rb
+++ b/lib/grpc_typechecker/grpc_ext.rb
@@ -22,11 +22,15 @@ module GRPC::GenericService
 
       mod = Module.new do
         singleton_class.class_eval do
-          # Some server interceptors try to obtain the service name by `method.owner.service_name`
+          # Some server interceptors try to obtain the service name by `method.owner.service_name` or `method.owner.to_s`.
           # despite `method` is overwritten by the method in this module.
-          # We thus redirect class method calls of `service_name` for compatibility.
+          # We thus redirect class method calls of `service_name` and `to_s` for compatibility.
           define_method :service_name do
             subclass.service_name
+          end
+
+          define_method :to_s do
+            subclass.to_s
           end
         end
       end


### PR DESCRIPTION
## Why

Some tracing libraries such as [dd-trace-rb](https://github.com/DataDog/dd-trace-rb) use `method.owner.to_s` to display.
Due to this behavior, if we use grpc_typechecker, the displayed name of classes is broken.

<img width="396" alt="image" src="https://user-images.githubusercontent.com/1477130/170274182-ecf4da6b-0312-4dca-bb0f-1ba15722fbbd.png">

Ref: https://github.com/DataDog/dd-trace-rb/blob/9fd04441f91f4668c6d31dcff2af2115b38318c0/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb#L68-L75

See also: https://github.com/wantedly/reloader_interceptor/pull/6

## What

Define method `to_s` to a prepended module to return the same value of `to_s` method of the wrapping class. This fixes the broken displayed name.

